### PR TITLE
Ui fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6974,9 +6974,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
-      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,11 @@ export default function App() {
     let indexRow = 0;
     while (rows > indexRow) {
       const cardsInARow = getQuestionsByRow(indexRow, triviaData);
-      rowList.push(<Row className='q-row'>{cardsInARow}</Row>);
+      rowList.push(
+        <Row key={indexRow} className='q-row'>
+          {cardsInARow}
+        </Row>,
+      );
       indexRow++;
     }
     setCards(rowList);
@@ -95,7 +99,7 @@ export default function App() {
     const rowData = [];
     triviaData.forEach((category, categoryIndex) => {
       rowData.push(
-        <Col className='q-col align-self-center'>
+        <Col key={categoryIndex} className='q-col align-self-center'>
           <QuestionCard
             height={height}
             questionDetails={category.questions[rowIndex]}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -34,7 +34,7 @@ export default function QuestionCard({ questionDetails, height }) {
       <FrontSide onClick={clickHandler} className='front-side'>
         <span dangerouslySetInnerHTML={getLabel()}></span>
       </FrontSide>
-      <BackSide onClick={clickHandler} className='front-side'>
+      <BackSide onClick={clickHandler} className='back-side'>
         <span dangerouslySetInnerHTML={getLabel()} />
       </BackSide>
     </Flippy>

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -24,18 +24,14 @@ export default function QuestionCard({ questionDetails, height }) {
       default:
     }
   };
-  const getLabel = event => {
-    return {
-      __html: view === View.question ? question : answer,
-    };
-  };
+
   return (
     <Flippy flipOnClick={true} flipDirection='vertical' style={height}>
       <FrontSide onClick={clickHandler} className='front-side'>
-        <span dangerouslySetInnerHTML={getLabel()}></span>
+        <span>{question}</span>
       </FrontSide>
       <BackSide onClick={clickHandler} className='back-side'>
-        <span dangerouslySetInnerHTML={getLabel()} />
+        <span>{answer}</span>
       </BackSide>
     </Flippy>
   );

--- a/src/components/Headers/Headers.js
+++ b/src/components/Headers/Headers.js
@@ -12,7 +12,7 @@ export default function Headers({ data }) {
   data &&
     data.forEach((category, index) =>
       headers.push(
-        <Col className='headers justify-content-center'>
+        <Col key={index} className='headers justify-content-center'>
           {category.category}
         </Col>,
       ),


### PR DESCRIPTION
Overview:
- Fixed forgotten unique keys on a few .ForEaches()
<img width="907" alt="Screen Shot 2019-12-02 at 11 22 00 AM" src="https://user-images.githubusercontent.com/43492172/69989854-65780c80-14f9-11ea-8d0a-4a6723cdacb6.png">
- Updated vulnerable packages
-  Updated UI color for back of card
- Removed dangerouslySetInnerHTML

Before:
![trivia-first](https://user-images.githubusercontent.com/43492172/69989975-a7a14e00-14f9-11ea-8728-101489810b36.gif)

After:
![trivia-second](https://user-images.githubusercontent.com/43492172/69989991-aff98900-14f9-11ea-9650-c659108da3bd.gif)
There was a very short delay in the back of the card rendering which I figured it was coming from the HTML being changed in the DOM.

- Deployed link https://cute-platypus-01.reshuffle.app